### PR TITLE
[BOJ_20364] 부동산 다툼

### DIFF
--- a/BOJ_20364/SHINMH.java
+++ b/BOJ_20364/SHINMH.java
@@ -1,0 +1,42 @@
+package BOJ.problem;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Main_20364 {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringBuilder sb = new StringBuilder();
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		int N = Integer.parseInt(st.nextToken());
+		int Q = Integer.parseInt(st.nextToken());
+		
+		boolean[] tree = new boolean[N+1];
+		for(int i = 0; i < Q; i++) {
+			int num = Integer.parseInt(br.readLine());
+			int j = num;
+			int min = Integer.MAX_VALUE;
+			
+			while(j > 0) {
+				if(tree[j]) {
+					min = j;
+				}
+				j /= 2;
+			}
+			if(j == 0) {
+				tree[num] = true;
+			}
+			
+			sb.append((min == Integer.MAX_VALUE ? 0 : min) + "\n");
+		}
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
1.  배열을 이용한 이진트리일 경우 원소의 부모는 원수/2인 것을 이용하여 부모노드를 탐색해서 검사함.