### PR TITLE
[BOJ_17827] 달팽이 리스트

### DIFF
--- a/BOJ_15900/TennisRitchie.java
+++ b/BOJ_15900/TennisRitchie.java
@@ -1,0 +1,49 @@
+package BJ;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class BJ_15900_이지훈 {
+	static int EdgeLen = 0; // 트리의 총 간선 개수
+	static ArrayList<Integer>[] Graph; // 각 정점과 인접하고 있는 정점들을 저장하는 배열
+	static boolean[] visited; // 방문 여부 판단 배열
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		int N = Integer.parseInt(br.readLine());
+		StringTokenizer st;
+		
+		Graph = new ArrayList[N + 1]; // 각 정점의 실제 값과 Graph배열의 index를 일치시켜주기위해 N+1개의 배열을 할당
+		visited = new boolean[N + 1]; 
+		
+		for (int i = 1; i <= N; i++) // 각 정점에 ArrayList 생성
+			Graph[i] = new ArrayList<>();
+
+		for (int i = 0; i < N - 1; i++) { // 정점 입력
+			st = new StringTokenizer(br.readLine());
+			int V1 = Integer.parseInt(st.nextToken());
+			int V2 = Integer.parseInt(st.nextToken());
+			// 인접한 두 정점을 서로의 인접 리스트에 넣어줌
+			Graph[V1].add(V2);
+			Graph[V2].add(V1);
+		}
+		DFS(1, 0); // 깊이 우선 탐색 실행
+		bw.write((EdgeLen % 2 == 0) ? "No" : "Yes");
+		bw.flush();
+	}
+
+	static void DFS(int V, int level) {
+		visited[V] = true; // 현재 정점을 방문했다고 check
+		if (Graph[V].size() == 1) // leaf 노드이면 현재 레벨 값을 트리의 총 간선 개수에 더해줌
+			EdgeLen += level;
+		for (int temp : Graph[V]) // 현재 정점의 인접 정점 순회
+			if (!visited[temp]) // 지금까지 방문하지 않은 노드라면 level+1을 해주고 해당 인접 정점으로 이동
+				DFS(temp, level + 1);
+	}
+}

--- a/BOJ_17827/TennisRitchie.java
+++ b/BOJ_17827/TennisRitchie.java
@@ -1,0 +1,33 @@
+package BJ;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class BOJ_17827_이지훈 {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st = null;
+		st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken()); // 노드의 개수
+		int M = Integer.parseInt(st.nextToken()); // 질문의 횟수
+		int V = Integer.parseInt(st.nextToken()); // N번 노드가 가리키는 노드
+
+		int[] C = new int[N]; // N개의 정수 C1~CN 담는 배열 
+		st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < N; i++) //N개의 정수 C1~CN 입력 
+			C[i] = Integer.parseInt(st.nextToken());
+		for (int i = 0; i < M; i++) {
+			int temp = Integer.parseInt(br.readLine()); // 질문 입력
+			if (temp < V - 1) // 사이클 이전의 값을 요구하면 바로 출력
+				bw.write(C[temp] + "\n");
+			else // 사이클 내부의 값을 요구하면 논리적으로 사이클만 따로 떼어내서 나머지 연산을 통해 해당 자리 수 출력
+				bw.write(C[(temp - (V - 1)) % (N - (V - 1)) + (V - 1)] + "\n");
+		}
+		bw.flush();
+	}
+}


### PR DESCRIPTION
문제 해결 아이디어 :
이 문제에서 사용되는 수열은 맨 끝의 수가 앞선 수를 가리켜 사이클이 형성되는 구조이다,
먼저 사이클이 형성되는 구간과 사이클 생성되기 전 선형 구간으로 총 2개의 구간을 논리적으로 자른다.
K번째 수에 대한 질문이 들어오면, 위에서 나눈 구간대로 만약 사이클이 형성되기 이전을 물어봤다면 바로 그 자리의 수를 출력해주고 사이클이 형성된 이후 구간에 대해 물어봤다면 K에서 사이클 형성 이전의 길이를 제거해주고 나온 값을 사이클의 길이로 나머지 연산을 통해 결과를 출력해준다.

