### PR TITLE
[BOJ_20364] 부동산 다툼

### DIFF
--- a/BOJ_20364/TennisRitchie.java
+++ b/BOJ_20364/TennisRitchie.java
@@ -1,0 +1,36 @@
+package BJ;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class BOJ_20364_이지훈 {
+	static boolean[] visited; // 땅이 점유 됐는지 여부 check
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st = null;
+		st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken()); // 땅 개수
+		int Q = Integer.parseInt(st.nextToken()); // 오리 수
+		visited = new boolean[N + 1]; // 완전 이진 트리의 각 노드의 점유 여부 저장 0 index는 사용 x
+		for (int i = 0; i < Q; i++) {
+			int AreaNum = Integer.parseInt(br.readLine());
+			bw.write(Check(AreaNum) + "\n");
+			visited[AreaNum] = true; // 현재 땅이 점유되었다고 check
+		}
+		bw.flush();
+	}
+	static int Check(int AreaNum) {
+		int firstMeetArea = 0; // 가장 먼저 만난 점유되어있는 땅 -> 해당 땅이 점유 가능하면 그대로 0출력
+		while (AreaNum > 0) {  //   					   해당 땅으로 가는 길에 점유되어있는 땅이 존재하면 가장 먼저 만난 점유되어있는 땅 출력
+			if (visited[AreaNum]) // 점유된 땅이면
+				firstMeetArea = AreaNum; // 현재 순회하고 있는 땅을 firstMeetArea에 넣어줌
+			AreaNum = AreaNum / 2; // 부모 노드로 이동
+		}
+		return firstMeetArea; // 결과 출력
+	}
+}


### PR DESCRIPTION
문제 해결 아이디어:
이 문제는 땅들이 완전 이진 트리로 구성되어있고 땅의 개수가 2^20개로 범위가 커서 링크를 타서 DFS를 구현하기에는 무리가 있다고 생각하여, 완전 이진 트리의 성질 (=>부모가 N이면 자식은 2N,2N+1)을 이용하여 오리가 점유하고 싶은 땅으로 먼저가서 점유된 땅인지 판단하고 부모 노드로 가는 연산 N/2를 계속 진행하여 루트 노드까지 올라가고 올라가는 동안 이미 점유된 땅을 만나면 0으로 초기화된 firstMeetArea에 점유된 땅을 계속 바꿔가면서 넣어준다.
DFS가 끝난 뒤 firstMeetArea가 0이라면 순회 중 점유된 땅을 만난 적이 없어 해당 땅을 점유할 수 있다고 출력하고 0이 아니라면 firstMeetArea에 저장된 변수가 제일 처음 만난 점유된 땅이므로 그 값을 출력해준다.