### PR TITLE
[BOJ_15900] 나무 탈출

### DIFF
--- a/BOJ_15900/cofls.java
+++ b/BOJ_15900/cofls.java
@@ -1,0 +1,52 @@
+package LinkedListTree;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_15900 {
+	static ArrayList<ArrayList<Integer>> tree= new ArrayList<>();
+	static int cnt;
+	static int N;
+	static int result = 0;
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		
+		for(int i=0;i<N+1;i++) {
+			tree.add(new ArrayList<>());
+		}
+		
+		int[] tmp = new int[2];
+		for(int i=1; i<N;i++) {
+			String[] input = br.readLine().split(" ");
+			for(int t=0;t<2;t++) {
+				tmp[t]=Integer.parseInt(input[t]);
+			}
+			tree.get(tmp[0]).add(tmp[1]); //양방향 인접리스트
+			tree.get(tmp[1]).add(tmp[0]);
+		}
+		
+		dfs(1,0,0); //루트노드 1부터 탐색
+		System.out.println((result % 2) == 0 ? "No" : "Yes");
+	
+	}
+	
+	private static void dfs(int cur, int prev , int cnt) {
+		for(int i=0; i<tree.get(cur).size();i++) {
+			int next = tree.get(cur).get(i);
+				if(next!=prev) {
+					dfs(next,cur,cnt+1);
+				}
+		}
+		//리프노드(노드의 사이즈가 1)일 때, 깊이 더해주기
+		if(tree.get(cur).size()==1) {
+			result += cnt;
+		}
+		
+	}
+}


### PR DESCRIPTION
문제 해결 아이디어:
성원이가 선공으로 먼저 말을 한 칸씩 옮기게 된다.
성원이가 이기려면 루트노드부터 각 리프노드까지의 깊이의 총합이 홀수가 되어야 한다.
각 노드에 어떤 노드가 인접했는지 나타내기 위해서 2차원 arraylist를 만들었다. 간선 정보를 입력 받으며 양방향으로 넣어주었다.
루트노드부터 dfs를 하였고 노드 사이즈가 1인 것으로 리프노드를 판단. 그때의 깊이를 모두 더해주었다. 결과값이 홀짝이냐에 따라 승패를 결정하였다.  