### PR TITLE
[BOJ_7576] 토마토

### DIFF
--- a/BOJ_1662/ParkSeRyeong.java
+++ b/BOJ_1662/ParkSeRyeong.java
@@ -1,0 +1,61 @@
+package stack_queue;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Stack;
+
+public class BOJ_1662_Compression {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+		String tmp = br.readLine();
+		int bracket_idx = 0;
+		String[] arr = new String[tmp.length()];
+		for (int i = 0; i < tmp.length(); i++) {
+			arr[i] = String.valueOf(tmp.charAt(i));
+			if (arr[i].equals("(")) {
+				bracket_idx++;
+			}
+		}
+		int[] bracket = new int[bracket_idx];
+
+		bracket_idx = 0;
+		int result = 0;
+
+		Stack<String> stack = new Stack<>();
+		for (String s : arr) {
+			if (!s.equals(")")) {
+				if (s.equals("(")) {
+					bracket_idx++;
+				}
+				stack.push(s);
+			} else {
+				bracket_idx--;
+				int cnt = 0;
+				while (!stack.peek().equals("(")) {
+					stack.pop();
+					cnt++;
+				}
+				stack.pop();
+				cnt += bracket[bracket_idx];
+				cnt *= Integer.parseInt(stack.pop());
+				bracket[bracket_idx] = 0;
+				if (bracket_idx - 1 < 0) {
+					result += cnt;
+					continue;
+				}
+				bracket[bracket_idx - 1] += cnt;
+			}
+		}
+		result += stack.size();
+		bw.write(String.valueOf(result));
+		bw.flush();
+		bw.close();
+		br.close();
+
+	}
+}

--- a/BOJ_2504/ParkSeRyeong.java
+++ b/BOJ_2504/ParkSeRyeong.java
@@ -1,0 +1,81 @@
+package stack_queue;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Stack;
+
+/* BufferedWriter 써보기!*/
+public class BOJ_2504_Bracket {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+		String tmp = br.readLine();
+		String[] arr = new String[tmp.length()];
+		for (int i = 0; i < tmp.length(); i++) {
+			arr[i] = String.valueOf(tmp.charAt(i));
+		}
+
+		Stack<String> stack = new Stack<>();
+		String bracket = "()[]";
+
+		for (String c : arr) {
+			if (c.equals("(") || c.equals("[")) {
+				stack.push(c);
+			}
+			else {
+				if (stack.isEmpty()) break;
+				if (stack.peek().equals("(") || stack.peek().equals("[")) {
+					if (c.equals(")") && stack.peek().equals("(")) {
+						stack.pop();
+						stack.push("2");
+					} else if (c.equals("]") && stack.peek().equals("[")) {
+						stack.pop();
+						stack.push("3");
+					}
+					else {
+						stack.clear();
+						break;
+					}
+				}
+				else {
+					int sum = 0;
+					while (!stack.isEmpty() && !bracket.contains(stack.peek())) {
+						sum += Integer.parseInt(stack.pop());
+					}
+					if (stack.isEmpty()) break;
+					if (c.equals(")") && stack.peek().equals("(")) {
+						stack.pop();
+						stack.push(Integer.toString(sum * 2));
+					} else if (c.equals("]") && stack.peek().equals("[")) {
+						stack.pop();
+						stack.push(Integer.toString(sum * 3));
+					}
+					else {
+						stack.clear();
+						break;
+					}
+				}
+			}
+		}
+		int total = 0;
+		if(!stack.isEmpty()) {
+			while (!stack.isEmpty()) {
+				if (bracket.contains(stack.peek())) {
+					total = 0;
+					break;
+				}
+				total += Integer.parseInt(stack.pop());
+			}
+		}
+		bw.write(String.valueOf(total));
+
+		br.close();
+		bw.flush();
+		bw.close();
+	}
+}

--- a/BOJ_7576/ParkSeRyeong.java
+++ b/BOJ_7576/ParkSeRyeong.java
@@ -1,0 +1,66 @@
+package stack_queue;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ_7576_Tomato {
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		System.setIn(new FileInputStream("src/stack_queue/tomato_test.txt"));
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		int M = Integer.parseInt(st.nextToken());
+		int N = Integer.parseInt(st.nextToken());
+		int[] dr = { -1, 1, 0, 0 };
+		int[] dc = { 0, 0, -1, 1 };
+
+		int[][] arr = new int[N][M];
+		Queue<int[]> q = new LinkedList<int[]>();
+
+		int zeros = 0;
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine(), " ");
+			for (int j = 0; j < M; j++) {
+				arr[i][j] = Integer.parseInt(st.nextToken());
+				if (arr[i][j] == 1) {
+					q.offer(new int[] { i, j, 0 });
+				} else if (arr[i][j] == -0) {
+					zeros++;
+				}
+			}
+		}
+
+		int min_change_cnt = 0;
+		int changedZero = 0;
+		while (!q.isEmpty()) {
+			int r = q.peek()[0];
+			int c = q.peek()[1];
+			min_change_cnt = q.peek()[2] + 1;
+
+			q.poll();
+			for (int i = 0; i < 4; i++) {
+				int nr = r + dr[i];
+				int nc = c + dc[i];
+				if (nr < 0 || nr > N - 1 || nc < 0 || nc > M - 1) continue;
+				if (arr[nr][nc] != 0) continue;
+				changedZero++;
+				arr[nr][nc] = 1;
+				q.offer(new int[] { nr, nc, min_change_cnt });
+			}
+		}
+		if (zeros != changedZero) min_change_cnt = -1;
+		else min_change_cnt--;
+		bw.write(String.valueOf(min_change_cnt));
+		br.close();
+		bw.flush();
+		bw.close();
+	}
+}


### PR DESCRIPTION
큐 사용
- 큐엔 (r,c) 와 그 좌표가 1로 변하는데까지 걸린 날을 count해서 넣음.
1. 처음 입력받을 때 1의 r,c  좌표를 큐에 offer, 0의 개수(zeros)도 세줌.
2. 큐에서 하나씩 poll하면서 그 인접해있는 0들을 모두 1로 바꿔주고, cnt+1해서 다시 큐에 넣어줌.
3. 바꿀 때마다 바뀌는 0의 개수를 count해주고, 처음에 셌던 0의 개수와 다르다면 -> 안 익은 토마토가 있다는 뜻이므로 -1
4. 마지막 큐의 값이 다 익기까지 걸린 날짜 = min_change_cnt이므로 출력