### PR TITLE
[BOJ_4256] 트리

### DIFF
--- a/Stack/BOJ_1662/leedg.java
+++ b/Stack/BOJ_1662/leedg.java
@@ -1,0 +1,68 @@
+package SSAFY_Algorithm.Stack.BOJ_1662;
+import java.io.*;
+import java.util.Stack;
+
+public class leedg {
+    private static final long leftBracket = -1;
+    public static void main(String[] arg) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        Stack<Long> S = new Stack<>(); //
+        String input = br.readLine();
+
+        long length = 0;
+        long num = 0, tmp = 0, cnt = 0;
+        for(int idx = 0; idx < input.length(); idx++) {
+            char ch = input.charAt(idx);
+
+            if(ch == '(') {
+                if(length > 1) {
+                    length--;
+                    S.push(length);
+                    S.push(num);
+                } else {
+                    S.push(num);
+                }
+                length = 0;
+                S.push(leftBracket);
+            } else if(ch == ')') {
+                tmp = 0;
+                while(!S.isEmpty()) {
+                    cnt = 0;
+                    tmp = S.pop();
+                    if(tmp == leftBracket) {
+                        cnt = S.pop();
+                        length *= cnt;
+                        if(!S.isEmpty() && S.peek() > 0) {
+                            length += S.pop();
+                        }
+                        S.push(length);
+                        length = 0;
+                        break;
+                    } else {
+                        length += tmp;
+                    }
+                }
+            } else {
+                num = ch - '0';
+                length++;
+                if(ch != ')' && idx == input.length() - 1) {
+                    if(S.isEmpty()) {
+                        S.push(length);
+                    } else {
+                        length += S.pop();
+                        S.push(length);
+                    }
+                }
+            }
+        }
+
+        length = 0;
+        while(!S.isEmpty()) {
+            length += S.pop();
+        }
+        bw.write(String.valueOf(length));
+        bw.close();
+        br.close();
+    }
+}

--- a/Stack/BOJ_2504/leedg.java
+++ b/Stack/BOJ_2504/leedg.java
@@ -1,0 +1,106 @@
+package SSAFY_Algorithm.Stack.BOJ_2504;
+
+import java.io.*;
+import java.util.Stack;
+
+public class leedg {
+    public static void main(String[] arg) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+        Stack<String> S = new Stack<>();
+        String input = br.readLine();
+        boolean flag = true;
+
+        loop:
+        for(int i = 0; i < input.length(); i++) {
+            char ch = input.charAt(i);
+            int tmp = 0;
+
+            switch(ch) {
+                //여는 괄호 들어오면 그냥 넣어줌
+                case '(':
+                    S.push(ch + "");
+                    break;
+                //닫는 괄호인 경우에는
+                case ')':
+                    //비어있거나 대괄호가 앞에 있는 경우에는 올바르지 않은 경우
+                    if(S.isEmpty() || (S.peek().charAt(0) == '[')) {
+                        flag = false;
+                        break loop;
+                    //비어있지 않고 괄호의 매칭이 이루어지는 경우에는
+                    } else if (!S.isEmpty() && S.peek().charAt(0) == '(') {
+                        S.pop();
+                        tmp = 2;
+                        //괄호 안에 다른 숫자가 존재하는 경우에는 그 숫자를 꺼내와서 더해줌
+                        if (!S.isEmpty() && !(S.peek().charAt(0) == '(') && !(S.peek().charAt(0) == '[')) {
+                            tmp = Integer.parseInt(S.pop());
+                            tmp += 2;
+                        }
+                        S.push(tmp + "");
+                    //그 외의 경우에는 괄호 밖을 탐색 => 곱셈해주는 경우
+                    } else {
+                        tmp = Integer.parseInt(S.pop());
+                        //괄호가 올바르지 않는 경우에는 탈출
+                        if(S.isEmpty() || S.peek().charAt(0) != '(') {
+                            flag = false;
+                            break loop;
+                        } else {
+                            S.pop();
+                            tmp *= 2;
+                            //해당 괄호 속에 있는 순자를 2 곱해주고 바깥을 탐색해서 바깥에 있는게 숫자인 경우에는 걔를 더해줌
+                            if (!S.isEmpty() && !(S.peek().charAt(0) == '(') && !(S.peek().charAt(0) == '[')) {
+                                tmp += Integer.parseInt(S.pop());
+                            }
+                            S.push(tmp + "");
+                        }
+                    }
+                    break;
+                //여는 괄호 들어오면 그냥 넣어줌
+                //아래 로직은 소괄호와 동일한 로직임
+                case '[':
+                    S.push(ch + "");
+                    break;
+                case ']':
+                    if(S.isEmpty() || (S.peek().charAt(0) == '(')) {
+                        flag = false;
+                        break loop;
+                    } else if (!S.isEmpty() && S.peek().charAt(0) == '[') {
+                        S.pop();
+                        tmp = 3;
+                        if (!S.isEmpty() && !(S.peek().charAt(0) == '(') && !(S.peek().charAt(0) == '[')) {
+                            tmp = Integer.parseInt(S.pop());
+                            tmp += 3;
+                        }
+                        S.push(tmp + "");
+                    } else {
+                        tmp = Integer.parseInt(S.pop());
+                        if(S.isEmpty() || S.peek().charAt(0) != '[') {
+                            flag = false;
+                            break loop;
+                        } else {
+                            S.pop();
+                            tmp *= 3;
+                            if (!S.isEmpty() && !(S.peek().charAt(0) == '(') && !(S.peek().charAt(0) == '[')) {
+                                tmp += Integer.parseInt(S.pop());
+                            }
+                            S.push(tmp + "");
+                        }
+                    }
+                    break;
+            }
+        }
+        if(S.isEmpty() || S.size() > 1 || S.peek().equals("(") || S.peek().equals(")") || S.peek().equals("]") || S.peek().equals("["))
+            flag = false;
+
+        if(!flag) {
+            sb.append(0);
+        } else {
+            sb.append(S.pop());
+        }
+
+        bw.write(String.valueOf(sb));
+        bw.close();
+        br.close();
+    }
+}

--- a/Tree/BOJ_4256/leedg.java
+++ b/Tree/BOJ_4256/leedg.java
@@ -1,0 +1,48 @@
+package SSAFY_Algorithm.Tree.BOJ_4256;
+
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class leedg {
+    private static int[] pre;
+    private static int[] in;
+    private static StringBuilder sb = new StringBuilder();
+    public static void main(String[] arg) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int TestCase = Integer.parseInt(br.readLine());
+        StringTokenizer stk;
+
+        while(TestCase --> 0) {
+            int N = Integer.parseInt(br.readLine());
+
+            pre = new int[N];
+            in = new int[N];
+
+            stk = new StringTokenizer(br.readLine());
+            for(int i = 0; i < N; i++) {
+                pre[i] = Integer.parseInt(stk.nextToken());
+            }
+
+            stk = new StringTokenizer(br.readLine());
+            for(int i = 0; i < N; i++) {
+                in[i] = Integer.parseInt(stk.nextToken());
+            }
+            post(0, N, 0);
+            sb.append("\n");
+        }
+        bw.write(String.valueOf(sb));
+        bw.close();
+        br.close();
+    }
+    private static void post(int start, int end, int root) {
+        for(int i = start; i < end; i++) {
+            if(pre[root] == in[i]) {
+                post(start, i, root + 1);
+                post(i + 1, end, root + i - start + 1);
+                sb.append(in[i]).append(" ");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Logic

전위, 중위 표기법을 가지고 후위 표기법으로 나타내는 문제
상당히 오래걸렸던 문제이다

재귀로 풀 수 있는 문제
전위의 루트를 중위에서 찾으면 해당 위치의 왼쪽 오른쪽은 서브 트리로 나누어지게됨
1. 전위 표기법의 루트를 가지고 중위 표기법에서 해당 위치를 찾아준다
2. 왼쪽, 오른쪽 서브트리로 분기한다.
  2-1. 왼쪽 서브트리의 루트 노드는 전위 표기법에서 상위 트리의 루트위치 + 1이다
  2-2. 오른쪽 서브트리의 루트 노드는 전위 표기법에서 상위 트리의 루트위치 + 중위 표기법에서 해당 루트노드와 동일한 idx - 탐색하기 시작한 위치 + 1
3. 2-2의 로직을 생각해내는데 계속 복잡하게 인덱싱을 조작하면서 더 꼬이게 되어 글로 풀어써보고 작성하니 잘 풀렸다.
4. 이 문제의 핵심은 문제에서 주어지는 수도코드를 보고 이해하여 코드에 적용시키는 것이라고 생각한다.
      => 이를 통해 글로 풀어써보고 인덱싱해주면 깔끔하게 풀린다