### PR TITLE
[BOJ_4256] 트리

### DIFF
--- a/Tree/BOJ_4256/shinmh.java
+++ b/Tree/BOJ_4256/shinmh.java
@@ -1,0 +1,58 @@
+package SSAFY_Algorithm.Trre.BOJ_4256;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+
+public class shinmh {
+	static int[] postOrder;
+	static int[] inOrder;
+	static int root;
+	static StringBuilder sb;
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		sb = new StringBuilder();
+		int TC = Integer.parseInt(br.readLine());
+		while(TC > 0) {
+			int N = Integer.parseInt(br.readLine());
+			postOrder = new int[N];
+			inOrder = new int[N];
+			
+			StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+			for(int i = 0; i < N; i++) {
+				postOrder[i] = Integer.parseInt(st.nextToken());
+			}
+			
+			st = new StringTokenizer(br.readLine(), " ");
+			for(int i = 0; i < N; i++) {
+				inOrder[i] = Integer.parseInt(st.nextToken());
+			}
+			
+			root = 0;
+			search(0, N-1);
+			sb.append("\n");
+			TC--;
+		}
+		bw.write(sb.toString());
+		bw.close();
+		br.close();
+	}
+	
+	static void search(int start, int end) {
+		int i;
+		for(i = start; i <= end; i++) {
+			if(postOrder[root] == inOrder[i]) {
+				root++;
+				search(start, i - 1);
+				search(i + 1, end);
+				sb.append(inOrder[i]).append(" ");
+				break;
+			}
+		}
+	}
+}


### PR DESCRIPTION
문제 해결을 위한 아이디어 :
선위순회한 값을 기준으로 중위순회한 값에서 찾아서 나온 값을 해당 트리의 root로 보고 왼쪽 부트리, 오른쪽 부트리로 분리하고, 다음 선위순회값을 찾도록 하였습니다. 다음 값이 다음 자식트리의 root이기 때문입니다. 해당 값을 마지막에 출력하도록하여 문제를 해결하였습니다.